### PR TITLE
feat: add session reset time status item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# https://github.com/oraios/serena
+.serena

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -6,6 +6,7 @@ import {
     renderStatusLine,
     getTokenMetrics,
     getSessionDuration,
+    getSessionResetTime,
     type RenderContext
 } from './utils/renderer';
 
@@ -56,6 +57,11 @@ async function renderMultipleLines(data: StatusJSON) {
         line.some(item => item.type === 'session-clock')
     );
 
+    // Check if session reset time is needed
+    const hasSessionResetTime = lines.some(line =>
+        line.some(item => item.type === 'session-reset-time')
+    );
+
     let tokenMetrics = null;
     if (hasTokenItems && data.transcript_path) {
         tokenMetrics = await getTokenMetrics(data.transcript_path);
@@ -66,11 +72,17 @@ async function renderMultipleLines(data: StatusJSON) {
         sessionDuration = await getSessionDuration(data.transcript_path);
     }
 
+    let sessionResetTime = null;
+    if (hasSessionResetTime && data.transcript_path) {
+        sessionResetTime = await getSessionResetTime(data.transcript_path);
+    }
+
     // Create render context
     const context: RenderContext = {
         data,
         tokenMetrics,
         sessionDuration,
+        sessionResetTime,
         isPreview: false
     };
 

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -427,7 +427,7 @@ const ItemsEditor: React.FC<ItemsEditorProps> = ({ items, onUpdate, onBack, line
                 // Toggle item type backwards
                 const types: StatusItemType[] = ['model', 'git-branch', 'git-changes', 'separator',
                     'tokens-input', 'tokens-output', 'tokens-cached', 'tokens-total', 'context-length', 'context-percentage', 'context-percentage-usable',
-                    'session-clock', 'terminal-width', 'version', 'flex-separator', 'custom-text', 'custom-command'];
+                    'session-clock', 'session-reset-time', 'terminal-width', 'version', 'flex-separator', 'custom-text', 'custom-command'];
                 const currentItem = items[selectedIndex];
                 if (currentItem) {
                     const currentType = currentItem.type;
@@ -444,7 +444,7 @@ const ItemsEditor: React.FC<ItemsEditorProps> = ({ items, onUpdate, onBack, line
                 // Toggle item type forwards
                 const types: StatusItemType[] = ['model', 'git-branch', 'git-changes', 'separator',
                     'tokens-input', 'tokens-output', 'tokens-cached', 'tokens-total', 'context-length', 'context-percentage', 'context-percentage-usable',
-                    'session-clock', 'terminal-width', 'version', 'flex-separator', 'custom-text', 'custom-command'];
+                    'session-clock', 'session-reset-time', 'terminal-width', 'version', 'flex-separator', 'custom-text', 'custom-command'];
                 const currentItem = items[selectedIndex];
                 if (currentItem) {
                     const currentType = currentItem.type;
@@ -590,6 +590,8 @@ const ItemsEditor: React.FC<ItemsEditorProps> = ({ items, onUpdate, onBack, line
                 return colorFunc('Context % (usable)');
             case 'session-clock':
                 return colorFunc('Session Clock');
+            case 'session-reset-time':
+                return colorFunc('Session Reset Time');
             case 'terminal-width':
                 return colorFunc('Terminal Width');
             case 'version':
@@ -713,7 +715,7 @@ const ColorMenu: React.FC<ColorMenuProps> = ({ items, onUpdate, onBack }) => {
         if (item.type === 'separator') {
             return showSeparators;
         }
-        return ['model', 'git-branch', 'git-changes', 'tokens-input', 'tokens-output', 'tokens-cached', 'tokens-total', 'context-length', 'context-percentage', 'context-percentage-usable', 'session-clock', 'terminal-width', 'version', 'custom-text', 'custom-command'].includes(item.type) &&
+        return ['model', 'git-branch', 'git-changes', 'tokens-input', 'tokens-output', 'tokens-cached', 'tokens-total', 'context-length', 'context-percentage', 'context-percentage-usable', 'session-clock', 'session-reset-time', 'terminal-width', 'version', 'custom-text', 'custom-command'].includes(item.type) &&
             !(item.type === 'custom-command' && item.preserveColors); // Exclude custom-command items with preserveColors
     });
     const [highlightedItemId, setHighlightedItemId] = useState<string | null>(colorableItems[0]?.id || null);
@@ -744,7 +746,7 @@ const ColorMenu: React.FC<ColorMenuProps> = ({ items, onUpdate, onBack }) => {
                 if (item.type === 'separator') {
                     return !showSeparators; // Will be toggled
                 }
-                return ['model', 'git-branch', 'git-changes', 'tokens-input', 'tokens-output', 'tokens-cached', 'tokens-total', 'context-length', 'context-percentage', 'context-percentage-usable', 'session-clock', 'terminal-width', 'version', 'custom-text', 'custom-command'].includes(item.type) &&
+                return ['model', 'git-branch', 'git-changes', 'tokens-input', 'tokens-output', 'tokens-cached', 'tokens-total', 'context-length', 'context-percentage', 'context-percentage-usable', 'session-clock', 'session-reset-time', 'terminal-width', 'version', 'custom-text', 'custom-command'].includes(item.type) &&
                     !(item.type === 'custom-command' && item.preserveColors);
             });
             if (newColorableItems.length > 0) {
@@ -811,6 +813,7 @@ const ColorMenu: React.FC<ColorMenuProps> = ({ items, onUpdate, onBack }) => {
             case 'context-percentage': return 'Context Percentage';
             case 'context-percentage-usable': return 'Context % (usable)';
             case 'session-clock': return 'Session Clock';
+            case 'session-reset-time': return 'Session Reset Time';
             case 'terminal-width': return 'Terminal Width';
             case 'version': return 'Version';
             case 'separator': return `Separator (${item.character || '|'})`;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -9,7 +9,7 @@ const writeFile = fs.promises?.writeFile || promisify(fs.writeFile);
 const mkdir = fs.promises?.mkdir || promisify(fs.mkdir);
 
 export type StatusItemType = 'model' | 'git-branch' | 'git-changes' | 'separator' | 'flex-separator' |
-    'tokens-input' | 'tokens-output' | 'tokens-cached' | 'tokens-total' | 'context-length' | 'context-percentage' | 'context-percentage-usable' | 'terminal-width' | 'session-clock' | 'version' | 'custom-text' | 'custom-command';
+    'tokens-input' | 'tokens-output' | 'tokens-cached' | 'tokens-total' | 'context-length' | 'context-percentage' | 'context-percentage-usable' | 'terminal-width' | 'session-clock' | 'session-reset-time' | 'version' | 'custom-text' | 'custom-command';
 
 export interface StatusItem {
     id: string;


### PR DESCRIPTION
## Summary
- Add new `session-reset-time` status item that displays time remaining until the current 5-hour Claude session expires
- Implement `getSessionResetTime()` function to calculate remaining session time from transcript files
- Add TUI configuration support for the new status item

## Features
- **Time calculation**: Reads first timestamp from transcript file and calculates when 5-hour session window expires
- **Display formats**: 
  - Standard: "Reset: 3h 15m" 
  - Raw value: "3h 15m"
- **Smart handling**: Returns `null` if session expired or no transcript available
- **Visual styling**: Uses orange color by default to indicate timing importance
- **TUI integration**: Fully configurable through the interactive interface

## Test plan
- [x] Verify compilation and build process
- [x] Test time calculation logic with sample transcript files
- [x] Confirm TUI includes new status item option
- [x] Validate rendering in both preview and actual modes
- [x] Check proper color application and formatting